### PR TITLE
Add support for PagerDuty Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'docker-api'
 
 gem 'slack-notifier'
 
+gem 'pagerduty', '3.0.0'
+
 gem 'redlock'
 
 gem 'dogstatsd-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     hiredis (0.6.3)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
+    json (2.5.1)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -108,6 +109,8 @@ GEM
     octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    pagerduty (3.0.0)
+      json (>= 1.7.7)
     pg (1.2.3)
     public_suffix (4.0.6)
     puma (4.3.7)
@@ -199,6 +202,7 @@ DEPENDENCIES
   hiredis
   listen (~> 3.2)
   octokit
+  pagerduty (= 3.0.0)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
@@ -214,7 +218,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.9

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ VINIFERA_ENABLE_BIG_FORK_SCANNING=false
 
 REDIS_URL=redis://<REDIS_URI>
 SIDEKIQ_REDIS_URL=redis://<REDIS_URI>
+
+# For PagerDuty Integration
+DEFAULT_PD_INTEGRATION_KEY=<xxxxxxxx>
+ENABLE_PAGER_DUTY_TRIGGER=true
 ```
 
 * Setup Cron Jobs
@@ -174,6 +178,23 @@ bundle exec sidekiq
 ##### Datadog
 
 Additionally, to get the metrics on Datadog like in the above screenshot, you can use the DataDog agent - [https://docs.datadoghq.com/agent/](https://docs.datadoghq.com/agent/)
+
+
+##### PagerDuty
+
+To ensure the team never misses any violation, PagerDuty integration option is there:
+
+For PagerDuty integration, following environment variable needs to be set to `true`
+
+```bash
+ENABLE_PAGER_DUTY_TRIGGER=true
+```
+
+Then create a new service and a integration key as described in following doc - https://support.pagerduty.com/docs/services-and-integrations#create-a-new-service
+
+```bash
+DEFAULT_PD_INTEGRATION_KEY=<xxxxxxxx>
+```
 
 ## Contributing
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,2 +1,9 @@
 class Report < ApplicationRecord
+  belongs_to :target
+
+  after_create_commit -> { PagerDutyNotificationWorker.perform_async(self.class.name, self.id) }, if: -> { ENV['ENABLE_PAGER_DUTY_TRIGGER'] }
+
+  def report_source
+    self.target.url
+  end
 end

--- a/app/models/stray_report.rb
+++ b/app/models/stray_report.rb
@@ -1,2 +1,7 @@
 class StrayReport < ApplicationRecord
+  after_create_commit -> { PagerDutyNotificationWorker.perform_async(self.class.name, self.id) }, if: -> { ENV['ENABLE_PAGER_DUTY_TRIGGER'] }
+
+  def report_source
+    self.url
+  end
 end

--- a/app/workers/pager_duty_notification_worker.rb
+++ b/app/workers/pager_duty_notification_worker.rb
@@ -1,0 +1,31 @@
+class PagerDutyNotificationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :notification, retry: 2
+
+  sidekiq_retries_exhausted do |msg, error|
+    message = "Error in *PagerDutyNotificationWorker* \n error #{msg}: `#{error}`"
+    SlackNotifier.new.notify(message, SlackNotifier::CHANNELS[:ERROR])
+  end
+
+  sidekiq_retry_in do |attempt, _|
+    (30 * (attempt + 1)).seconds.to_i
+  end
+
+  def perform(model_klass, id)
+    return if Rails.cache.exist?("pager_duty_alert_#{model_klass}_#{id}")
+
+    model_details = model_klass.constantize.find(id)
+    source = model_details.report_source
+    incident_opts = {
+      class: model_klass,
+      source: source,
+      summary: "#{model_klass} violation detected",
+      timestamp: model_details.created_at,
+      custom_details: model_details.attributes.except('meta_data').merge(source: source)
+    }
+
+    PagerDutyClient.new.create_incident(incident_opts)
+
+    Rails.cache.write("pager_duty_alert_#{model_klass}_#{id}", expires_in: 30.minutes)
+  end
+end

--- a/lib/pager_duty_client.rb
+++ b/lib/pager_duty_client.rb
@@ -1,0 +1,16 @@
+class PagerDutyClient
+  DEFAULT_API_VERSION = 2
+
+  INCIDENT_SEVERITIES = { critical: 'critical', error: 'error', warning: 'warning', info: 'info' }.freeze
+
+  def initialize(opts = {})
+    @client = Pagerduty.build(integration_key: opts[:integration_key] || ENV['DEFAULT_PD_INTEGRATION_KEY'], api_version: opts[:api_version] || DEFAULT_API_VERSION)
+  end
+
+  def create_incident(opts = {})
+    default_opts = { summary: 'Default Summary', source: 'Vinifera', severity: INCIDENT_SEVERITIES[:critical] }
+    @client.trigger(default_opts.merge(opts))
+  end
+end
+
+


### PR DESCRIPTION
To ensure critical violations are not missed, we have added support for PagerDuty Integration. 

This is being used in production to respond to leaks efficiently so they can be addressed accordingly. 

